### PR TITLE
Use label instead of maintainer instruction in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:3.5
 
-MAINTAINER ZappiStore DevOps <devops@zappistore.com>
-
 ARG SYSLOG_NG_VERSION="3.7.2-r3"
 
 RUN apk --update add \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.5
 
+LABEL maintainer "Zappi DevOps <devops@zappistore.com>"
+
 ARG SYSLOG_NG_VERSION="3.7.2-r3"
 
 RUN apk --update add \


### PR DESCRIPTION
Because it has been deprecated.